### PR TITLE
Always use prebuilt_any in prebuilt etc gen

### DIFF
--- a/fsgen/filesystem_creator_test.go
+++ b/fsgen/filesystem_creator_test.go
@@ -295,23 +295,23 @@ func TestPrebuiltEtcModuleGen(t *testing.T) {
 		}),
 	).RunTest(t)
 
-	checkModuleProp := func(m android.Module, matcher func(actual interface{}) bool) bool {
+	getModuleProp := func(m android.Module, matcher func(actual interface{}) string) string {
 		for _, prop := range m.GetProperties() {
 
-			if matcher(prop) {
-				return true
+			if str := matcher(prop); str != "" {
+				return str
 			}
 		}
-		return false
+		return ""
 	}
 
 	// check generated prebuilt_* module type install path and install partition
-	generatedModule := result.ModuleForTests("system-frameworks_base_config-etc-0", "android_arm64_armv8-a").Module()
+	generatedModule := result.ModuleForTests("system-frameworks_base_config-etc-0", "android_common").Module()
 	etcModule, _ := generatedModule.(*etc.PrebuiltEtc)
 	android.AssertStringEquals(
 		t,
-		"module expected to have etc install path",
-		"etc",
+		"module expected to have . install path",
+		".",
 		etcModule.BaseDir(),
 	)
 	android.AssertBoolEquals(
@@ -324,14 +324,65 @@ func TestPrebuiltEtcModuleGen(t *testing.T) {
 	)
 
 	// check generated prebuilt_* module specifies correct relative_install_path property
-	generatedModule = result.ModuleForTests("system-frameworks_base_data_keyboards-usr_keylayout_subdir-0", "android_arm64_armv8-a").Module()
+	generatedModule = result.ModuleForTests("system-frameworks_base_data_keyboards-usr_keylayout_subdir-0", "android_common").Module()
 	etcModule, _ = generatedModule.(*etc.PrebuiltEtc)
 	android.AssertStringEquals(
 		t,
-		"module expected to set correct relative_install_path properties",
-		"subdir",
-		etcModule.SubDir(),
+		"module expected to set correct srcs property",
+		"Vendor_0079_Product_0011.kl",
+		getModuleProp(generatedModule, func(actual interface{}) string {
+			if p, ok := actual.(*etc.PrebuiltEtcProperties); ok {
+				srcs := p.Srcs.GetOrDefault(eval, nil)
+				if len(srcs) == 2 {
+					return srcs[0];
+				}
+			}
+			return ""
+		}),
 	)
+	android.AssertStringEquals(
+		t,
+		"module expected to set correct srcs property",
+		"Vendor_0079_Product_18d4.kl",
+		getModuleProp(generatedModule, func(actual interface{}) string {
+			if p, ok := actual.(*etc.PrebuiltEtcProperties); ok {
+				srcs := p.Srcs.GetOrDefault(eval, nil)
+				if len(srcs) == 2 {
+					return srcs[1];
+				}
+			}
+			return ""
+		}),
+	)
+	android.AssertStringEquals(
+		t,
+		"module expected to set correct dsts property",
+		"usr/keylayout/subdir/Vendor_0079_Product_0011.kl",
+		getModuleProp(generatedModule, func(actual interface{}) string {
+			if p, ok := actual.(*etc.PrebuiltDstsProperties); ok {
+				dsts := p.Dsts.GetOrDefault(eval, nil)
+				if len(dsts) == 2 {
+					return dsts[0];
+				}
+			}
+			return ""
+		}),
+	)
+	android.AssertStringEquals(
+		t,
+		"module expected to set correct dsts property",
+		"usr/keylayout/subdir/Vendor_0079_Product_18d4.kl",
+		getModuleProp(generatedModule, func(actual interface{}) string {
+			if p, ok := actual.(*etc.PrebuiltDstsProperties); ok {
+				dsts := p.Dsts.GetOrDefault(eval, nil)
+				if len(dsts) == 2 {
+					return dsts[1];
+				}
+			}
+			return ""
+		}),
+	)
+
 
 	// check that prebuilt_* module is not generated for non existing source file
 	android.AssertPanicMessageContains(
@@ -342,64 +393,133 @@ func TestPrebuiltEtcModuleGen(t *testing.T) {
 	)
 
 	// check that duplicate src file can exist in PRODUCT_COPY_FILES and generates separate modules
-	generatedModule0 := result.ModuleForTests("product-device_sample_etc-etc-0", "android_arm64_armv8-a").Module()
-	generatedModule1 := result.ModuleForTests("product-device_sample_etc-etc-1", "android_arm64_armv8-a").Module()
+	generatedModule0 := result.ModuleForTests("product-device_sample_etc-etc-0", "android_common").Module()
+	generatedModule1 := result.ModuleForTests("product-device_sample_etc-etc-1", "android_common").Module()
 
 	// check that generated prebuilt_* module sets correct srcs and dsts property
-	eval := generatedModule0.ConfigurableEvaluator(android.PanickingConfigAndErrorContext(result.TestContext))
-	android.AssertBoolEquals(
+	eval = generatedModule0.ConfigurableEvaluator(android.PanickingConfigAndErrorContext(result.TestContext))
+	android.AssertStringEquals(
 		t,
 		"module expected to set correct srcs property",
-		true,
-		checkModuleProp(generatedModule0, func(actual interface{}) bool {
+		"apns-full-conf.xml",
+		getModuleProp(generatedModule0, func(actual interface{}) string {
 			if p, ok := actual.(*etc.PrebuiltEtcProperties); ok {
 				srcs := p.Srcs.GetOrDefault(eval, nil)
-				return len(srcs) == 1 &&
-					srcs[0] == "apns-full-conf.xml"
+				if len(srcs) == 1 {
+					return srcs[0];
+				}
 			}
-			return false
+			return ""
 		}),
 	)
-	android.AssertBoolEquals(
+	android.AssertStringEquals(
 		t,
 		"module expected to set correct dsts property",
-		true,
-		checkModuleProp(generatedModule0, func(actual interface{}) bool {
+		"etc/apns-conf.xml",
+		getModuleProp(generatedModule0, func(actual interface{}) string {
 			if p, ok := actual.(*etc.PrebuiltDstsProperties); ok {
 				dsts := p.Dsts.GetOrDefault(eval, nil)
-				return len(dsts) == 1 &&
-					dsts[0] == "apns-conf.xml"
+				if len(dsts) == 1 {
+					return dsts[0];
+				}
 			}
-			return false
+			return ""
 		}),
 	)
 
 	// check that generated prebuilt_* module sets correct srcs and dsts property
 	eval = generatedModule1.ConfigurableEvaluator(android.PanickingConfigAndErrorContext(result.TestContext))
-	android.AssertBoolEquals(
+	android.AssertStringEquals(
 		t,
 		"module expected to set correct srcs property",
-		true,
-		checkModuleProp(generatedModule1, func(actual interface{}) bool {
+		"apns-full-conf.xml",
+		getModuleProp(generatedModule1, func(actual interface{}) string {
 			if p, ok := actual.(*etc.PrebuiltEtcProperties); ok {
 				srcs := p.Srcs.GetOrDefault(eval, nil)
-				return len(srcs) == 1 &&
-					srcs[0] == "apns-full-conf.xml"
+				if len(srcs) == 1 {
+					return srcs[0];
+				}
 			}
-			return false
+			return ""
 		}),
 	)
-	android.AssertBoolEquals(
+	android.AssertStringEquals(
 		t,
 		"module expected to set correct dsts property",
-		true,
-		checkModuleProp(generatedModule1, func(actual interface{}) bool {
+		"etc/apns-conf-2.xml",
+		getModuleProp(generatedModule1, func(actual interface{}) string {
 			if p, ok := actual.(*etc.PrebuiltDstsProperties); ok {
 				dsts := p.Dsts.GetOrDefault(eval, nil)
-				return len(dsts) == 1 &&
-					dsts[0] == "apns-conf-2.xml"
+				if len(dsts) == 1 {
+					return dsts[0];
+				}
 			}
-			return false
+			return ""
+		}),
+	)
+
+	generatedModule2 := result.ModuleForTests(t, "system-device_sample_etc-foo-0", "android_common").Module()
+	generatedModule3 := result.ModuleForTests(t, "system-device_sample_etc-foo-1", "android_common").Module()
+
+	// check that generated prebuilt_* module sets correct srcs and dsts property
+	eval = generatedModule2.ConfigurableEvaluator(android.PanickingConfigAndErrorContext(result.TestContext))
+	android.AssertStringEquals(
+		t,
+		"module expected to set correct srcs property",
+		"apns-full-conf.xml",
+		getModuleProp(generatedModule2, func(actual interface{}) string {
+			if p, ok := actual.(*etc.PrebuiltEtcProperties); ok {
+				srcs := p.Srcs.GetOrDefault(eval, nil)
+				if len(srcs) == 1 {
+					return srcs[0];
+				}
+			}
+			return ""
+		}),
+	)
+	android.AssertStringEquals(
+		t,
+		"module expected to set correct dsts property",
+		"foo/file.txt",
+		getModuleProp(generatedModule2, func(actual interface{}) string {
+			if p, ok := actual.(*etc.PrebuiltDstsProperties); ok {
+				dsts := p.Dsts.GetOrDefault(eval, nil)
+				if len(dsts) == 1 {
+					return dsts[0];
+				}
+			}
+			return ""
+		}),
+	)
+
+	// check that generated prebuilt_* module sets correct srcs and dsts property
+	eval = generatedModule3.ConfigurableEvaluator(android.PanickingConfigAndErrorContext(result.TestContext))
+	android.AssertStringEquals(
+		t,
+		"module expected to set correct srcs property",
+		"apns-full-conf.xml",
+		getModuleProp(generatedModule2, func(actual interface{}) string {
+			if p, ok := actual.(*etc.PrebuiltEtcProperties); ok {
+				srcs := p.Srcs.GetOrDefault(eval, nil)
+				if len(srcs) == 1 {
+					return srcs[0];
+				}
+			}
+			return ""
+		}),
+	)
+	android.AssertStringEquals(
+		t,
+		"module expected to set correct dsts property",
+		"foo/apns-full-conf.xml",
+		getModuleProp(generatedModule3, func(actual interface{}) string {
+			if p, ok := actual.(*etc.PrebuiltDstsProperties); ok {
+				dsts := p.Dsts.GetOrDefault(eval, nil)
+				if len(dsts) == 1 {
+					return dsts[0];
+				}
+			}
+			return ""
 		}),
 	)
 }

--- a/fsgen/prebuilt_etc_modules_gen.go
+++ b/fsgen/prebuilt_etc_modules_gen.go
@@ -186,56 +186,6 @@ type prebuiltInstallInRootProperties struct {
 	Install_in_root *bool
 }
 
-var (
-	etcInstallPathToFactoryList = map[string]android.ModuleFactory{
-		"":                    etc.PrebuiltRootFactory,
-		"avb":                 etc.PrebuiltAvbFactory,
-		"bin":                 etc.PrebuiltBinaryFactory,
-		"bt_firmware":         etc.PrebuiltBtFirmwareFactory,
-		"cacerts":             etc.PrebuiltEtcCaCertsFactory,
-		"dsp":                 etc.PrebuiltDSPFactory,
-		"etc":                 etc.PrebuiltEtcFactory,
-		"etc/dsp":             etc.PrebuiltDSPFactory,
-		"etc/firmware":        etc.PrebuiltFirmwareFactory,
-		"firmware":            etc.PrebuiltFirmwareFactory,
-		"gpu":                 etc.PrebuiltGPUFactory,
-		"first_stage_ramdisk": etc.PrebuiltFirstStageRamdiskFactory,
-		"fonts":               etc.PrebuiltFontFactory,
-		"framework":           etc.PrebuiltFrameworkFactory,
-		"lib":                 etc.PrebuiltRenderScriptBitcodeFactory,
-		"lib64":               etc.PrebuiltRenderScriptBitcodeFactory,
-		"lib/rfsa":            etc.PrebuiltRFSAFactory,
-		"media":               etc.PrebuiltMediaFactory,
-		"odm":                 etc.PrebuiltOdmFactory,
-		"optee":               etc.PrebuiltOpteeFactory,
-		"overlay":             etc.PrebuiltOverlayFactory,
-		"priv-app":            etc.PrebuiltPrivAppFactory,
-		"radio":               etc.PrebuiltRadioFactory,
-		"thh":                 etc.PrebuiltThhFactory,
-		"install":             etc.PrebuiltInstallFactory,
-		"addon.d":             etc.PrebuiltAddonDFactory,
-		"camera":              etc.PrebuiltCameraFactory,
-		"app":                 etc.PrebuiltAppFactory,
-		"sbin":                etc.PrebuiltSbinFactory,
-		"system":              etc.PrebuiltSystemFactory,
-		"res":                 etc.PrebuiltResFactory,
-		"rfs":                 etc.PrebuiltRfsFactory,
-		"tts":                 etc.PrebuiltVoicepackFactory,
-		"tvconfig":            etc.PrebuiltTvConfigFactory,
-		"tvservice":           etc.PrebuiltTvServiceFactory,
-		"usr/share":           etc.PrebuiltUserShareFactory,
-		"usr/hyphen-data":     etc.PrebuiltUserHyphenDataFactory,
-		"usr/keylayout":       etc.PrebuiltUserKeyLayoutFactory,
-		"usr/keychars":        etc.PrebuiltUserKeyCharsFactory,
-		"usr/srec":            etc.PrebuiltUserSrecFactory,
-		"usr/idc":             etc.PrebuiltUserIdcFactory,
-		"vendor":              etc.PrebuiltVendorFactory,
-		"vendor_dlkm":         etc.PrebuiltVendorDlkmFactory,
-		"wallpaper":           etc.PrebuiltWallpaperFactory,
-		"wlc_upt":             etc.PrebuiltWlcUptFactory,
-	}
-)
-
 func generatedPrebuiltEtcModuleName(partition, srcDir, destDir string, count int) string {
 	// generated module name follows the pattern:
 	// <install partition>-<src file path>-<relative install path from partition root>-<number>
@@ -296,18 +246,6 @@ func prebuiltEtcModuleProps(ctx android.LoadHookContext, moduleName, partition, 
 func createPrebuiltEtcModulesInDirectory(ctx android.LoadHookContext, partition, srcDir, destDir string, destFiles []srcBaseFileInstallBaseFileTuple) (moduleNames []string) {
 	groupedDestFiles, maxLen := groupDestFilesBySrc(destFiles)
 
-	// Find out the most appropriate module type to generate
-	var etcInstallPathKey string
-	for _, etcInstallPath := range android.SortedKeys(etcInstallPathToFactoryList) {
-		// Do not break when found but iterate until the end to find a module with more
-		// specific install path
-		if strings.HasPrefix(destDir, etcInstallPath) {
-			etcInstallPathKey = etcInstallPath
-		}
-	}
-	moduleFactory := etcInstallPathToFactoryList[etcInstallPathKey]
-	relDestDirFromInstallDirBase, _ := filepath.Rel(etcInstallPathKey, destDir)
-
 	for fileIndex := range maxLen {
 		srcTuple := []srcBaseFileInstallBaseFileTuple{}
 		for _, srcFile := range android.SortedKeys(groupedDestFiles) {
@@ -322,12 +260,8 @@ func createPrebuiltEtcModulesInDirectory(ctx android.LoadHookContext, partition,
 		modulePropsPtr := &moduleProps
 		propsList := []interface{}{modulePropsPtr}
 
-		allCopyFileNamesUnchanged := true
 		var srcBaseFiles, installBaseFiles []string
 		for _, tuple := range srcTuple {
-			if tuple.srcBaseFile != tuple.installBaseFile {
-				allCopyFileNamesUnchanged = false
-			}
 			srcBaseFiles = append(srcBaseFiles, tuple.srcBaseFile)
 			installBaseFiles = append(installBaseFiles, tuple.installBaseFile)
 		}
@@ -342,36 +276,17 @@ func createPrebuiltEtcModulesInDirectory(ctx android.LoadHookContext, partition,
 			})
 		}
 
-		// Set appropriate srcs, dsts, and releative_install_path based on
-		// the source and install file names
-		if allCopyFileNamesUnchanged {
-			modulePropsPtr.Srcs = srcBaseFiles
-
-			// Specify relative_install_path if it is not installed in the root directory of the
-			// partition
-			if !android.InList(relDestDirFromInstallDirBase, []string{"", "."}) {
-				propsList = append(propsList, &prebuiltSubdirProperties{
-					Relative_install_path: proptools.StringPtr(relDestDirFromInstallDirBase),
-				})
-			}
-		} else {
-			// If dsts property has to be set and the selected module type is prebuilt_root,
-			// use prebuilt_any instead.
-			if etcInstallPathKey == "" {
-				moduleFactory = etc.PrebuiltAnyFactory
-			}
-			modulePropsPtr.Srcs = srcBaseFiles
-			dsts := proptools.NewConfigurable[[]string](nil, nil)
-			for _, installBaseFile := range installBaseFiles {
-				dsts.AppendSimpleValue([]string{filepath.Join(relDestDirFromInstallDirBase, installBaseFile)})
-			}
-
-			propsList = append(propsList, &etc.PrebuiltDstsProperties{
-				Dsts: dsts,
-			})
+		modulePropsPtr.Srcs = srcBaseFiles
+		dsts := proptools.NewConfigurable[[]string](nil, nil)
+		for _, installBaseFile := range installBaseFiles {
+			dsts.AppendSimpleValue([]string{filepath.Join(destDir, installBaseFile)})
 		}
 
-		ctx.CreateModuleInDirectory(moduleFactory, srcDir, propsList...)
+		propsList = append(propsList, &etc.PrebuiltDstsProperties{
+			Dsts: dsts,
+		})
+
+		ctx.CreateModuleInDirectory(etc.PrebuiltAnyFactory, srcDir, propsList...)
 		moduleNames = append(moduleNames, moduleName)
 	}
 


### PR DESCRIPTION
We now use the Dsts property to manage the
target destinations of the copy rule.

Before there was special care put in place to not
use Dsts in case src and dst filename matched, but this broke prebuilt_any usage in these cases.

We can't easily switch to prebuilt_any in those cases unless we also remove support for prebuilt_root as this specfic module doesn't support have the Dsts
property to avoid installing files in arbitrary locations, so we're "forced" to do the whole migration as a whole.

Also add a few test cases to ensure prebuilt_any works as expected (the latter test woudln't pass before)

Test: m --no-skip-soong-tests
Change-Id: I0c9985a6174090ce3ae6bf3201cca090377f5967

[error.log](https://github.com/user-attachments/files/19462971/error.log)